### PR TITLE
2 tiny changes and support for 3 other docstring formats in config

### DIFF
--- a/lib/python-docstring.js
+++ b/lib/python-docstring.js
@@ -3,6 +3,21 @@
 import { CompositeDisposable } from 'atom';
 
 export default {
+  // see: https://stackoverflow.com/questions/3898572/what-is-the-standard-python-docstring-format
+  config: {
+    docstringFormat: {
+      title: 'Docstring format',
+      description: 'Choose among different common docstring formats.',
+      type: 'string',
+      default: 'Google docstring format',
+      enum: [
+        'Google docstring format',
+        'Numpydoc docstring format',
+        'reST (Sphinx) docstring format',
+        'Epytext/Edpydoc docstring format',
+      ],
+    },
+  },
 
   subscriptions: null,
 
@@ -26,23 +41,82 @@ export default {
       var pos = editor.getCursorBufferPosition();
       var column = pos.column;
 
-      var docstring =
-        '"""\n' +
-        ' '.repeat(column) + 'A short description.\n' +
-        '\n' +
-        ' '.repeat(column) + 'A bit longer description.\n' +
-        '\n' +
-        ' '.repeat(column) + 'Args:\n' +
-        ' '.repeat(column) + '    variable (type): description\n' +
-        '\n' +
-        ' '.repeat(column) + 'Returns:\n' +
-        ' '.repeat(column) + '    type: description\n' +
-        '\n' +
-        ' '.repeat(column) + 'Raises:\n' +
-        ' '.repeat(column) + '    Exception: description\n' +
-        '\n' +
-        ' '.repeat(column) + '"""\n' +
-        ' '.repeat(column);
+      // see: https://stackoverflow.com/questions/3898572/what-is-the-standard-python-docstring-format
+      var docstringStyle = atom.config.get('python-docstring.docstringFormat');
+      switch(docstringStyle) {
+        case 'Epytext/Edpydoc docstring format':
+          var docstring =
+            '"""\n' +
+            ' '.repeat(column) + 'A short description.\n' +
+            '\n' +
+            ' '.repeat(column) + 'A bit longer description.\n' +
+            '\n' +
+            ' '.repeat(column) + '@param variable (type): description\n' +
+            ' '.repeat(column) + '@return (type): description\n' +
+            ' '.repeat(column) + '@raise Exception1: description\n' +
+            '\n' +
+            ' '.repeat(column) + '"""\n' +
+            ' '.repeat(column);
+          break;
+        case 'reST (Sphinx) docstring format':
+          var docstring =
+            '"""\n' +
+            ' '.repeat(column) + 'A short description.\n' +
+            '\n' +
+            ' '.repeat(column) + 'A bit longer description.\n' +
+            '\n' +
+            ' '.repeat(column) + ':param variable (type): description\n' +
+            ' '.repeat(column) + ':returns (type): description\n' +
+            ' '.repeat(column) + ':raises Exception1: description\n' +
+            '\n' +
+            ' '.repeat(column) + '"""\n' +
+            ' '.repeat(column);
+          break;
+        case 'Numpydoc docstring format':
+          var docstring =
+            '"""\n' +
+            ' '.repeat(column) + 'A short description.\n' +
+            '\n' +
+            ' '.repeat(column) + 'A bit longer description.\n' +
+            '\n' +
+            ' '.repeat(column) + 'Parameters\n' +
+            ' '.repeat(column) + '----------\n' +
+            ' '.repeat(column) + 'variable : type\n' +
+            ' '.repeat(column) + '    description\n' +
+            '\n' +
+            ' '.repeat(column) + 'Returns\n' +
+            ' '.repeat(column) + '-------\n' +
+            ' '.repeat(column) + 'type\n' +
+            ' '.repeat(column) + '    description\n' +
+            '\n' +
+            ' '.repeat(column) + 'Raises\n' +
+            ' '.repeat(column) + '------\n' +
+            ' '.repeat(column) + 'Exception\n' +
+            ' '.repeat(column) + '    description\n' +
+            '\n' +
+            ' '.repeat(column) + '"""\n' +
+            ' '.repeat(column);
+          break;
+        default: // 'Google docstring format'
+          var docstring =
+            '"""\n' +
+            ' '.repeat(column) + 'A short description.\n' +
+            '\n' +
+            ' '.repeat(column) + 'A bit longer description.\n' +
+            '\n' +
+            ' '.repeat(column) + 'Args:\n' +
+            ' '.repeat(column) + '    variable (type): description\n' +
+            '\n' +
+            ' '.repeat(column) + 'Returns:\n' +
+            ' '.repeat(column) + '    type: description\n' +
+            '\n' +
+            ' '.repeat(column) + 'Raises:\n' +
+            ' '.repeat(column) + '    Exception: description\n' +
+            '\n' +
+            ' '.repeat(column) + '"""\n' +
+            ' '.repeat(column);
+      }
+
       editor.insertText(docstring);
     }
   }

--- a/lib/python-docstring.js
+++ b/lib/python-docstring.js
@@ -26,21 +26,23 @@ export default {
       var pos = editor.getCursorBufferPosition();
       var column = pos.column;
 
-      editor.insertText('"""\n');
-      editor.insertText(' '.repeat(column) + 'A short description.\n');
-      editor.insertText('\n');
-      editor.insertText(' '.repeat(column) + 'A bit longer description.\n');
-      editor.insertText('\n');
-      editor.insertText(' '.repeat(column) + 'Args:\n');
-      editor.insertText(' '.repeat(column) + '    variable (type): description\n');
-      editor.insertText('\n');
-      editor.insertText(' '.repeat(column) + 'Returns:\n');
-      editor.insertText(' '.repeat(column) + '    type: description\n');
-      editor.insertText('\n');
-      editor.insertText(' '.repeat(column) + 'Raises:\n');
-      editor.insertText(' '.repeat(column) + '    Exception: description\n');
-      editor.insertText('\n');
-      editor.insertText(' '.repeat(column) + '"""\n');
+      var docstring =
+        '"""\n' +
+        ' '.repeat(column) + 'A short description.\n' +
+        '\n' +
+        ' '.repeat(column) + 'A bit longer description.\n' +
+        '\n' +
+        ' '.repeat(column) + 'Args:\n' +
+        ' '.repeat(column) + '    variable (type): description\n' +
+        '\n' +
+        ' '.repeat(column) + 'Returns:\n' +
+        ' '.repeat(column) + '    type: description\n' +
+        '\n' +
+        ' '.repeat(column) + 'Raises:\n' +
+        ' '.repeat(column) + '    Exception: description\n' +
+        '\n' +
+        ' '.repeat(column) + '"""\n';
+      editor.insertText(docstring);
     }
   }
 

--- a/lib/python-docstring.js
+++ b/lib/python-docstring.js
@@ -41,7 +41,8 @@ export default {
         ' '.repeat(column) + 'Raises:\n' +
         ' '.repeat(column) + '    Exception: description\n' +
         '\n' +
-        ' '.repeat(column) + '"""\n';
+        ' '.repeat(column) + '"""\n' +
+        ' '.repeat(column);
       editor.insertText(docstring);
     }
   }


### PR DESCRIPTION
Hey, I started docstring-ing a python script I had and had an indenting problem when inserting the docstring: the next line always lost an indent level.
And when I wanted to remove the just inserted docstring, I had to undo all lines separately. Now it's all in one variable and inserted altogether.
Finally I wanted to try some other docstrings-types and entered them. This last step was just for myself, but I though I'd just as well add it, now that I've coded it, so don't feel bad to delete that part if you don't like it :see_no_evil: : 